### PR TITLE
Handle command output without blocking

### DIFF
--- a/process/manager.go
+++ b/process/manager.go
@@ -42,6 +42,7 @@ func (m *Manager) Start(cmd *exec.Cmd) ([]byte, error) {
 
 	processExitChan := make(chan error, 1)
 
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	cmd.Stdout = stdout
@@ -64,7 +65,7 @@ func (m *Manager) Start(cmd *exec.Cmd) ([]byte, error) {
 
 	select {
 	case <-m.killAll:
-		cmd.Process.Signal(syscall.SIGTERM)
+		syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
 		<-processExitChan
 		return combinedOutput(), errors.New("SIGTERM propagated to child process")
 	case retVal := <-processExitChan:


### PR DESCRIPTION
Remove use of bufio.Scanner in favor of just writing to a bytes.Buffer
object. When a termination signal is received on the "killAll" channel
wait for the managed process to exit before reading buffer output.

The stdout test emits 128K + 1 bytes now in order to trigger a test
failure with the old implementation where scanner.Scan() would consume
the first 64K bytes, and the stdout pipe will be filled with the next
64K bytes leading a blocking condition by the next byte.  This is fixed
by the current implementation.

See: https://github.com/pivotal-cf/service-backup-release/issues/8

[#160826467]