### PR TITLE
REDVM-339 add logic for larger files azure

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -8,9 +8,11 @@ package azure
 
 import (
 	"code.cloudfoundry.org/lager/v3"
+	"encoding/base64"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/pivotal-cf/service-backup/process"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +26,9 @@ type AzureClient struct {
 	endpoint     string
 	remotePathFn func() string
 }
+
+const ChunkSize = 8 * 1024 * 1024 // 8MB
+const Limit = 64 * 1024 * 1024    // 64MB
 
 func New(name, accountKey, accountName, container, endpoint string, remotePathFn func() string) *AzureClient {
 	return &AzureClient{
@@ -52,12 +57,49 @@ func (a *AzureClient) uploadFile(sessionLogger lager.Logger, containerReference 
 		return fmt.Errorf("error in uploadFile could not open file: %w", err)
 	}
 	defer file.Close()
-
-	blob := containerReference.GetBlobReference(remoteFilePath)
-
-	err = blob.CreateBlockBlobFromReader(file, &storage.PutBlobOptions{})
+	stat, err := file.Stat()
 	if err != nil {
-		return fmt.Errorf("error in uploadFile could not create block: %w", err)
+		return fmt.Errorf("error in uploadFile could not get stats of file: %w", err)
+	}
+	blob := containerReference.GetBlobReference(remoteFilePath)
+	// single file limit
+	if stat.Size() < Limit {
+		// The API will reject requests with size > 256 MiB
+		err = blob.CreateBlockBlobFromReader(file, &storage.PutBlobOptions{})
+		if err != nil {
+			return fmt.Errorf("error in uploadFile could not create block blob from reader: %w", err)
+		}
+	} else {
+		err = blob.CreateBlockBlob(&storage.PutBlobOptions{})
+		if err != nil {
+			return fmt.Errorf("error in uploadFile cloud not create block blob: %w", err)
+		}
+		buffer := make([]byte, ChunkSize)
+		blocks := []storage.Block{}
+		for i := 0; ; i++ {
+			bytesRead, err := file.Read(buffer)
+			if err != nil {
+				if err == io.EOF {
+					break
+				} else {
+					return fmt.Errorf("error in uploadFile could not read file to buffer: %w", err)
+				}
+			}
+			chunk := buffer[:bytesRead]
+			blockID := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("BlockID{%07d}", i)))
+			err = blob.PutBlock(blockID, chunk, &storage.PutBlockOptions{})
+			if err != nil {
+				return fmt.Errorf("error in uploadFile could not put block: %w", err)
+			}
+			blocks = append(blocks, storage.Block{
+				ID:     blockID,
+				Status: storage.BlockStatusUncommitted,
+			})
+		}
+		err = blob.PutBlockList(blocks, &storage.PutBlockListOptions{})
+		if err != nil {
+			return fmt.Errorf("error in uploadFile put list of blocks: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Test CI: https://runway-ci.eng.vmware.com/teams/tanzu-redis/pipelines/service-backup-fix-azure-limit

From the azure-sdk [docs](https://pkg.go.dev/github.com/curoverse/azure-sdk-for-go/storage#Blob.CreateBlockBlobFromReader) _`CreateBlockBlobFromReader` the API rejects requests with size > 256 MiB (but the SDK does not check this limit). To write a bigger blob, use `CreateBlockBlob`, `PutBlock`, and `PutBlockList`._

I added the respective logic for files larger than 64MB to upload in chunks of 8MB sequentially. The test uploads a 100MB file using the new logic.

Docs & useful information:
* https://pkg.go.dev/github.com/curoverse/azure-sdk-for-go/storage
* https://azure.microsoft.com/en-us/updates/retirement-notice-the-legacy-azure-storage-go-client-libraries-will-be-retired-on-13-september-2024/

It is a possibility to make this concurrent for faster upload, but there was no reference to this being supported on the SDK docs.