### PR TITLE
TNZ-20557: fixes ginkgo version in the script

### DIFF
--- a/scripts/test_integration
+++ b/scripts/test_integration
@@ -26,7 +26,7 @@ SERVICE_BACKUP_TESTS_GCP_PROJECT_NAME=${SERVICE_BACKUP_TESTS_GCP_PROJECT_NAME:?}
 
 pushd "${BASE_DIR}"
   GO111MODULE=off go get -t -v -d ./...
-  go install github.com/onsi/ginkgo/v2/ginkgo@v1.22.0
+  go install github.com/onsi/ginkgo/v2/ginkgo@v2.20.2
   ./scripts/run_parallel_tests.sh --skip-package scpintegration,release_tests
   go tool cover -func=coverprofile.out
 popd


### PR DESCRIPTION
The current updated ginkgo version is invalid. fixes the ginkgo version to the v2.20.2
