### PR TITLE
TNZ-20579: adds retry logic for service-backup release tests

### DIFF
--- a/release_tests/release_test.go
+++ b/release_tests/release_test.go
@@ -76,7 +76,26 @@ var _ = Describe("release tests", func() {
 		cmd := exec.Command("bosh", allArgs...)
 		cmd.Stdout = stdout
 		cmd.Stderr = GinkgoWriter
-		Expect(cmd.Run()).To(Succeed())
+
+		var cmdError error
+		maxRetry := 3
+		sleepTime := time.Second * 30
+
+		for attempt := 0; attempt < maxRetry; attempt++ {
+			cmdError = cmd.Run()
+			if cmdError == nil {
+				break
+			}
+
+			GinkgoWriter.Printf("failed to execute BOSH command %s\n", allArgs)
+			if attempt == maxRetry-1 {
+				break
+			}
+			GinkgoWriter.Printf("retrying after %.0f seconds\n", sleepTime.Seconds())
+			time.Sleep(sleepTime)
+		}
+
+		Expect(cmdError).To(BeNil())
 	}
 
 	boshCmdWithGateway := func(stdout io.Writer, command string, args ...string) {


### PR DESCRIPTION
we have started seeing too many errors when running tests in CI. these errors are related to the limitation of number of connections per minute. Hence, adding retry logic with some cool down period to retry the same command.